### PR TITLE
make actors with level header use all level export

### DIFF
--- a/fast64_internal/sm64/settings/properties.py
+++ b/fast64_internal/sm64/settings/properties.py
@@ -99,7 +99,7 @@ class SM64_Properties(PropertyGroup):
             "exportType": "export_type",
         }
         old_export_props_to_new = {
-            "custom_export_name": {"geoLevelName", "colLevelName", "animLevelName"},
+            "custom_group_name": {"geoLevelName", "colLevelName", "animLevelName"},
             "custom_export_path": {"geoExportPath", "colExportPath", "animExportPath"},
             "object_name": {"geoName", "colName", "animName"},
             "group_name": {"geoGroupName", "colGroupName", "animGroupName"},

--- a/fast64_internal/sm64/sm64_collision.py
+++ b/fast64_internal/sm64/sm64_collision.py
@@ -331,34 +331,31 @@ def exportCollisionC(
     cDefFile.write(cDefine)
     cDefFile.close()
 
-    if not customExport:
-        if headerType == "Actor":
-            # Write to group files
-            if groupName == "" or groupName is None:
-                raise PluginError("Actor header type chosen but group name not provided.")
+    if headerType == "Actor":
+        # Write to group files
+        if groupName == "" or groupName is None:
+            raise PluginError("Actor header type chosen but group name not provided.")
 
-            groupPathC = os.path.join(dirPath, groupName + ".c")
-            groupPathH = os.path.join(dirPath, groupName + ".h")
+        groupPathC = os.path.join(dirPath, groupName + ".c")
+        groupPathH = os.path.join(dirPath, groupName + ".h")
 
-            writeIfNotFound(groupPathC, '\n#include "' + name + '/collision.inc.c"', "")
-            if writeRoomsFile:
-                writeIfNotFound(groupPathC, '\n#include "' + name + '/rooms.inc.c"', "")
-            else:
-                deleteIfFound(groupPathC, '\n#include "' + name + '/rooms.inc.c"')
-            writeIfNotFound(groupPathH, '\n#include "' + name + '/collision_header.h"', "\n#endif")
+        writeIfNotFound(groupPathC, '\n#include "' + name + '/collision.inc.c"', "")
+        if writeRoomsFile:
+            writeIfNotFound(groupPathC, '\n#include "' + name + '/rooms.inc.c"', "")
+        else:
+            deleteIfFound(groupPathC, '\n#include "' + name + '/rooms.inc.c"')
+        writeIfNotFound(groupPathH, '\n#include "' + name + '/collision_header.h"', "\n#endif")
 
-        elif headerType == "Level":
-            groupPathC = os.path.join(dirPath, "leveldata.c")
-            groupPathH = os.path.join(dirPath, "header.h")
+    elif headerType == "Level":
+        groupPathC = os.path.join(dirPath, "leveldata.c")
+        groupPathH = os.path.join(dirPath, "header.h")
 
-            writeIfNotFound(groupPathC, '\n#include "levels/' + levelName + "/" + name + '/collision.inc.c"', "")
-            if writeRoomsFile:
-                writeIfNotFound(groupPathC, '\n#include "levels/' + levelName + "/" + name + '/rooms.inc.c"', "")
-            else:
-                deleteIfFound(groupPathC, '\n#include "levels/' + levelName + "/" + name + '/rooms.inc.c"')
-            writeIfNotFound(
-                groupPathH, '\n#include "levels/' + levelName + "/" + name + '/collision_header.h"', "\n#endif"
-            )
+        writeIfNotFound(groupPathC, '\n#include "levels/' + levelName + "/" + name + '/collision.inc.c"', "")
+        if writeRoomsFile:
+            writeIfNotFound(groupPathC, '\n#include "levels/' + levelName + "/" + name + '/rooms.inc.c"', "")
+        else:
+            deleteIfFound(groupPathC, '\n#include "levels/' + levelName + "/" + name + '/rooms.inc.c"')
+        writeIfNotFound(groupPathH, '\n#include "levels/' + levelName + "/" + name + '/collision_header.h"', "\n#endif")
 
     return cDefine
 
@@ -502,12 +499,12 @@ class SM64_ExportCollision(bpy.types.Operator):
             applyRotation([obj], math.radians(90), "X")
             if context.scene.fast64.sm64.export_type == "C":
                 export_path, level_name = getPathAndLevel(
-                    props.export_header_type == "Custom",
-                    props.custom_export_path,
-                    props.custom_export_name,
-                    props.actor_level_name,
+                    props.is_actor_custom_export,
+                    props.actor_custom_path,
+                    props.export_level_name,
+                    props.level_name,
                 )
-                if not props.export_header_type == "Custom":
+                if not props.is_actor_custom_export:
                     applyBasicTweaks(export_path)
                 exportCollisionC(
                     obj,
@@ -516,10 +513,10 @@ class SM64_ExportCollision(bpy.types.Operator):
                     False,
                     props.include_children,
                     props.obj_name_col,
-                    props.export_header_type == "Custom",
+                    props.is_actor_custom_export,
                     props.export_rooms,
                     props.export_header_type,
-                    props.export_group_name,
+                    props.actor_group_name,
                     level_name,
                 )
                 self.report({"INFO"}, "Success!")

--- a/fast64_internal/sm64/sm64_geolayout_writer.py
+++ b/fast64_internal/sm64/sm64_geolayout_writer.py
@@ -2847,12 +2847,12 @@ class SM64_ExportGeolayoutObject(ObjectDataExporter):
 
             if context.scene.fast64.sm64.export_type == "C":
                 export_path, level_name = getPathAndLevel(
-                    props.export_header_type == "Custom",
-                    props.custom_export_path,
-                    props.custom_export_name,
-                    props.actor_level_name,
+                    props.is_actor_custom_export,
+                    props.actor_custom_path,
+                    props.export_level_name,
+                    props.level_name,
                 )
-                if not props.export_header_type == "Custom":
+                if not props.is_actor_custom_export:
                     applyBasicTweaks(export_path)
                 exportGeolayoutObjectC(
                     obj,
@@ -2862,12 +2862,12 @@ class SM64_ExportGeolayoutObject(ObjectDataExporter):
                     save_textures,
                     save_textures and bpy.context.scene.geoSeparateTextureDef,
                     None,
-                    props.export_group_name,
+                    props.actor_group_name,
                     props.export_header_type,
                     props.obj_name_gfx,
                     props.geo_name,
                     level_name,
-                    props.export_header_type == "Custom",
+                    props.is_actor_custom_export,
                     DLFormat.Static,
                 )
                 self.report({"INFO"}, "Success!")
@@ -3044,14 +3044,14 @@ class SM64_ExportGeolayoutArmature(bpy.types.Operator):
             bpy.ops.object.transform_apply(location=False, rotation=True, scale=True, properties=False)
             if context.scene.fast64.sm64.export_type == "C":
                 export_path, level_name = getPathAndLevel(
-                    props.export_header_type == "Custom",
-                    props.custom_export_path,
-                    props.custom_export_name,
-                    props.actor_level_name,
+                    props.is_actor_custom_export,
+                    props.actor_custom_path,
+                    props.export_level_name,
+                    props.level_name,
                 )
 
                 save_textures = bpy.context.scene.saveTextures
-                if not props.export_header_type == "Custom":
+                if not props.is_actor_custom_export:
                     applyBasicTweaks(export_path)
                 header, fileStatus = exportGeolayoutArmatureC(
                     armatureObj,
@@ -3062,12 +3062,12 @@ class SM64_ExportGeolayoutArmature(bpy.types.Operator):
                     save_textures,
                     save_textures and bpy.context.scene.geoSeparateTextureDef,
                     None,
-                    props.export_group_name,
+                    props.actor_group_name,
                     props.export_header_type,
                     props.obj_name_gfx,
                     props.geo_name,
                     level_name,
-                    props.export_header_type == "Custom",
+                    props.is_actor_custom_export,
                     DLFormat.Static,
                 )
                 starSelectWarning(self, fileStatus)

--- a/fast64_internal/utility.py
+++ b/fast64_internal/utility.py
@@ -418,17 +418,17 @@ def extendedRAMLabel(layout):
     infoBox.label(text="Extended RAM prevents crashes.")
 
 
-def getPathAndLevel(customExport, exportPath, levelName, levelOption):
-    if customExport:
-        exportPath = bpy.path.abspath(exportPath)
-        levelName = levelName
+def getPathAndLevel(is_custom_export, custom_export_path, custom_level_name, level_enum):
+    if is_custom_export:
+        export_path = bpy.path.abspath(custom_export_path)
+        level_name = custom_level_name
     else:
-        exportPath = bpy.path.abspath(bpy.context.scene.fast64.sm64.decomp_path)
-        if levelOption == "Custom":
-            levelName = levelName
+        export_path = bpy.path.abspath(bpy.context.scene.fast64.sm64.decomp_path)
+        if level_enum == "Custom":
+            level_name = custom_level_name
         else:
-            levelName = levelOption
-    return exportPath, levelName
+            level_name = level_enum
+    return export_path, level_name
 
 
 def findStartBones(armatureObj):


### PR DESCRIPTION
- custom group name has a more clear name
- actors use custom export logic if they `non_decomp_level` and the export header type is `Level` or if the header type is `Custom`
- added some props to make actor pathing make more sense
- renamed some vars to be more clear
- fixed bhv names appearing when not exporting behaviors
- added warning if exporting to custom group that doesn't exist